### PR TITLE
Fix price filter in listings view - search function

### DIFF
--- a/listings/views.py
+++ b/listings/views.py
@@ -56,7 +56,7 @@ def search(request):
   # Price
   if 'price' in request.GET:
     price = request.GET['price']
-    if price:
+    if price and price < list(price_choices.keys())[-1]: 
       queryset_list = queryset_list.filter(price__lte=price)
 
   context = {


### PR DESCRIPTION
If the last price filter option was selected, we should look for listings with the max price of "1M+" which basically means that we can skip this filter at all.
The existing solution will unfortunately still run the "lesser than or equal to" filter.